### PR TITLE
Update the config structure name to follow the Beego newest version

### DIFF
--- a/setting/setting.go
+++ b/setting/setting.go
@@ -13,7 +13,7 @@ const (
 )
 
 var (
-	conf config.ConfigContainer
+	conf config.Configer
 )
 
 var (


### PR DESCRIPTION
The newest Beego version has changed the name of config.ConfigContainer structure,it should be  updated to wrench synchronously.

Signed-off-by: MabinGo <bin.ma@huawei.com>